### PR TITLE
Ability to compare sprints

### DIFF
--- a/model.py
+++ b/model.py
@@ -1,0 +1,120 @@
+__author__ = 'yfedevych'
+
+from itertools import groupby
+import re
+
+class TestResult(object):
+
+    __slots__ = (
+        '_id',
+        'suite',
+        'test_id',
+        'title',
+        'description',
+        'component',
+        'result',
+        'error',
+        'sprint',
+        'attributes',
+        'component_modified'
+    )
+
+    _normalize_regex = re.compile('[\'\"\(\)\[\]\.,\+\s\*@#\$%\^&\?]')
+
+    @property
+    def component_normalized(self):
+        if self.component is None:
+            return None
+        return TestResult._normalize_regex.sub('-', self.component)
+
+    @property
+    def sprint_normalized(self):
+        if self.sprint is None:
+            return None
+        return TestResult._normalize_regex.sub('-', self.sprint)
+
+    def __init__(self, **kwargs):
+        for x in self.__slots__:
+            setattr(self, x, kwargs.get(x, None))
+
+    def __hash__(self):
+        return hash(tuple([
+            self.result,
+            self.test_id,
+            self.suite
+        ]))
+
+    def __eq__(self, other):
+        return (
+            self.result == other.result and
+            self.test_id == other.test_id and
+            self.suite == other.suite
+        )
+
+    def __getitem__(self, item):
+        return getattr(self, item)
+
+    def __setitem__(self, item, value):
+        return setattr(self, item, value)
+
+def compare_sprints(db, *sprints, **query):
+    """
+    Returns a dictionary containing items unique to each sprint
+    result, keyed by sprint.
+    """
+    def _get_results(db, sprint, **query):
+        """
+        A helper function that hydrates database results into a collection of
+        objects
+        """
+        return {TestResult(sprint=sprint, **rec) for rec in db.get_test_results(sprint, **query)}
+
+    ressets = {}
+    result = {}
+
+    for sprint in sprints:
+        ressets[sprint] = _get_results(db, sprint, **query)
+
+    for sprint in sprints:
+        #
+        # strip the result sets to only elements that are not
+        # present elsewhere. others is a set containing results
+        # from elsewhere.
+        #
+        othersprints = [x for x in sprints if x != sprint]
+        others = {x for key in othersprints for x in ressets[key]}
+        result[sprint] = {x for x in ressets[sprint] if x not in others}
+    return result
+
+def common_results(db, *sprints, **query):
+    """
+    Returns a set containing items common to all sprints.
+    """
+    def _get_results(db, sprint, **query):
+        """
+        A helper function that hydrates database results into a collection of
+        objects
+        """
+        result = db.get_test_results(sprint, **query)
+        return {TestResult(sprint=sprint, **rec) for rec in result}
+
+    ressets = {}
+    for sprint in sprints:
+        ressets[sprint] = _get_results(db, sprint, **query)
+
+    sprint = sprints[0]
+    othersprints = sprints[1:]
+    others = {x for key in othersprints for x in ressets[key]}
+    result = others.intersection(ressets[sprint])
+
+    return result
+
+
+
+def regroup_results(results, *keys):
+
+    def keyfunc(x):
+        return tuple([getattr(x, k) for k in keys])
+    res = list(results)
+    res.sort(key=keyfunc)
+    return groupby(res, keyfunc)

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -1,0 +1,84 @@
+{% extends 'base.html' %}
+{% from 'macros.html' import render_test_results %}
+{% block menu %}
+
+        <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                {{ project }} <b class="caret"></b>
+            </a>
+
+            <ul class="dropdown-menu">
+
+                {% for p in projects%}
+
+                <li><a href="/{{ p }}">{{ p }}</a></li>
+
+                {% endfor %}
+
+            </ul>
+        </li>
+
+        <li class="dropdown">
+
+            {% if sprints %}
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                    {{ sprint }} <b class="caret"></b>
+                </a>
+
+                <ul class="dropdown-menu">
+
+                    {% for s in sprints%}
+                    <li><a href="/{{ project }}/{{ s }}">{{ s }}</a></li>
+                    {% endfor %}
+
+                </ul>
+            {% else %}
+                <a href="/{{ project }}/{{ sprint }}">{{ sprint }} </a>
+            {% endif %}
+
+        </li>
+
+{% endblock %}
+
+
+{% block body %}
+    {% if compared_sprints|length == 1 %}
+        <h2>Comparing <a href="/{{ project }}/{{ sprint }}">{{ sprint }}</a>
+            with
+            <a href="/{{ project }}/{{ compared_sprints[0] }}">{{ compared_sprints[0] }}</a>
+        </h2>
+    {% else %}
+    <h2>Comparing <a href="/{{ project }}/{{ sprint }}">{{ sprint }}</a> with
+            {% for s in compared_sprints %}
+                <a href="/{{ project }}/{{ s }}">{{ s }}</a>{% if loop.index < compared_sprints|length %},{% endif %}
+            {% endfor %}
+    </h2>
+    {% endif %}
+    {% if common_results %}
+        <div class="panel panel-default">
+        <div class="panel-heading"><h4>{{ common_results }} failures common to these sprints
+            <button class="btn btn-info btn-sm" data-toggle="collapse" data-target="#commonFailures" role="button" type="button">toggle</button>
+        </h4></div>
+        <div class="panel-body collapse" id="commonFailures">
+            {{ render_test_results(grouped_common_results) }}
+        </div>
+        </div>
+    {% else %}
+        <div class="well well-lg">There are no results common to these sprints.</div>
+    {% endif %}
+    {% if not comparison_length %}
+        <div class="well well-lg">There are no failures unique to sprints being compared.</div>
+    {% else %}
+        {% for spr in comparison %}
+            <div class="panel panel-default">
+                <div class="panel-heading"><h4>
+                    {{ comparison_sizes[spr] }} Failures unique to <a href="/{{ project }}/{{ spr }}">{{ spr }}</a>
+                    <button class="btn btn-info btn-sm" data-toggle="collapse" data-target="#uniques_{{ loop.index }}" role="button" type="button">toggle</button>
+                </h4></div>
+                <div class="panel-body collapse in" id="uniques_{{ loop.index }}">
+                    {{ render_test_results(comparison[spr]) }}
+                </div>
+            </div>
+        {% endfor %}
+    {% endif %}
+{% endblock %}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,0 +1,62 @@
+{% macro testresult(result) %}
+    <a class="list-group-item
+        {% if result.result in ('failed', 'error') %}
+            list-group-item-danger
+        {% elif result.result == 'success' %}
+            list-group-item-success
+        {% endif %}
+    " data-toggle="modal" data-target="#ModalError{{ result.sprint_normalized }}{{ result.component_normalized }}{{ result.suite }}{{ result.test_id }}">
+            <h4 class="list-group-item-heading">
+                <small><span class="label
+                    {% if result.result in ('failed', 'error') %}
+                    label-danger
+                    {% elif result.result == 'success' %}
+                    label-success
+                    {% else %}
+                    label-default
+                    {% endif %}">{{ result.result }}</span></small>
+                {{ result.test_id }}
+            </h4>
+            <p class="list-group-item-text">{{ result.title }}</p>
+            {% if result.attributes %}
+                <p class="list-group-item-text text-right">
+                {% for key, value in result.attributes %}
+                    <small><span class="label label-default">{{ key }}: {{ value }}</span></small>
+                {% endfor %}
+                </p>
+            {% endif %}
+    </a>
+
+    <div class="modal fade" id="ModalError{{ result.sprint_normalized }}{{ result.component_normalized }}{{ result.suite }}{{ result.test_id }}" tabindex="-1" role="dialog" aria-labelledby="ModalLabelModalError{{ result.component_modified }}{{ result.suite }}{{ result.test_id }}" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                    <h4 class="modal-title" id="myModalErrorLabel">Error: {{ result.component }}: {{ result.suite }}: {{ result.test_id }}</h4>
+                </div>
+                <div class="modal-body">
+                    <pre>
+{{ result.error }}
+                    </pre>
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endmacro %}
+
+{% macro render_test_results(results) %}
+    {% for component in results|sort %}
+        <h3 class="head-component">{{ component }}</h3>
+        {% for suite in results[component]|sort %}
+            <div class="panel panel-default">
+            <div class="panel-heading"><h4>{{ suite }}</h4></div>
+            <div class="list-group">
+            {% for result in results[component][suite] %}
+                {{ testresult(result) }}
+            {% endfor %}
+            </div>
+            </div>
+        {% endfor %}
+    {% endfor %}
+{% endmacro %}

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,10 +1,56 @@
 {% extends "base.html" %}
-
+{% from "macros.html" import render_test_results %}
 {% block customjs %}
 
 <script type="text/javascript">
 
     $(document).ready(function() {
+
+        var toggleCompareRow = function(tr) {
+            var cb = tr.find('input');
+            if (cb.is(':checked')) {
+                tr.addClass('list-group-item-success');
+            } else {
+                tr.removeClass('list-group-item-success');
+            }
+        };
+
+        var countComparisonRows = function() {
+            var x = $('.cmprow input:checked');
+            if (!x.length) {
+                $('#compareSubmit').attr('disabled', 'disabled');
+                $('#comparisonCounter').hide();
+                $('#comparisonCounter').html('no sprint selected');
+            } else if (x.length == 1) {
+                $('#compareSubmit').attr('disabled', null);
+                $('#comparisonCounter').show();
+                $('#comparisonCounter').html('one sprint selected');
+            } else {
+                $('#compareSubmit').attr('disabled', null);
+                $('#comparisonCounter').show();
+                $('#comparisonCounter').html(x.length.toString()+' sprints selected');
+            }
+        }
+
+        $('.cmprow').each(function(){ toggleCompareRow($(this)); });
+        countComparisonRows();
+
+        $('#cmpSprintsToggle').click(function(){
+           $('#compareSprints').toggle();
+        });
+
+        $('.cmprow').click(function(){
+            var cb = $(this).find('input');
+            cb.trigger('click');
+        });
+
+        $('.cmprow input').click(function(event){
+            event.stopPropagation();
+            var cb = $(this);
+            var tr = cb.closest('a');
+            toggleCompareRow(tr);
+            countComparisonRows();
+        });
 
         $("#spanContextFailed").click(function() {
 
@@ -130,61 +176,33 @@
         </ul>
 
         {% if failed_tests %}
+        <form action="/compare/{{ project }}/{{ sprint }}" method="GET">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    Compare Sprints
+                    <button type="button" class="btn btn-info btn-sm" data-toggle="collapse" role="button" data-target="#compareSprints">toggle</button>
+                    <button type="submit" id="compareSubmit" class="btn btn-sm btn-success">Go <i class="glyphicon glyphicon-chevron-right"></i></button>
+                    <span class="badge" id="comparisonCounter"></span>
+                </div>
+                <div class="collapse list-group" id="compareSprints">
+                    {% for s in sprints %}
+                        {% if s != sprint %}
+                            <a class="cmprow list-group-item container">
+                                <span class="col-sm-1"><input type="checkbox" name="sprint" value="{{ s }}"></span>
+                                <span class="col">{{ s }}</span>
+                            </a>
+                        {% endif %}
+                    {% endfor %}
+                </div>
+            </div>
+        </form>
+
+
 
         <br>
 
         <div style="display:none" id="failedTestsList">
-            <table class="table">
-
-                <tr>
-                    <th>Component</th>
-                    <th>Suite</th>
-                    <th>Test ID</th>
-                    <th>Attributes</th>
-                    <th>Title</th>
-                    <th>Result</th>
-                </tr>
-
-                {% for result in failed_tests %}
-
-                    <tr class="danger">
-
-                        <td>{{ result.component }}</td>
-                        <td>{{ result.suite }}</td>
-                        <td>{{ result.test_id }}</td>
-
-                        <td>
-                            {% if 'attributes' in result %}
-                                {% for key, value in result.attributes %}
-                                    <small><span class="label label-default">{{ key }}: {{ value }}</span></small>
-                                {% endfor %}
-                            {% endif %}
-                        </td>
-
-                        <td>{{ result.title }}</td>
-                        <td data-toggle="modal" data-target="#ModalError{{ result.component_modified }}{{ result.suite }}{{ result.test_id }}">{{ result.result }}</td>
-
-                    </tr>
-
-                    <div class="modal fade" id="ModalError{{ result.component_modified }}{{ result.suite }}{{ result.test_id }}" tabindex="-1" role="dialog" aria-labelledby="ModalLabelModalError{{ result.component_modified }}{{ result.suite }}{{ result.test_id }}" aria-hidden="true">
-                        <div class="modal-dialog">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                    <h4 class="modal-title" id="myModalErrorLabel">Error: {{ result.component }}: {{ result.suite }}: {{ result.test_id }}</h4>
-                                </div>
-                                <div class="modal-body">
-                                    <pre>
-{{ result.error }}
-                                    </pre>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                {% endfor %}
-
-            </table>
+            {{ render_test_results(failed_tests) }}
         </div>
 
         {% endif %}


### PR DESCRIPTION
This pull request adds ability to compare test runs (sprints) to one another. Select one or more sprints from a form, and see a page with:
- failed results common to runs being compared (occurring in two or more runs)
- failed results unique to each run

The comparison pages are GET, and thus are bookmarkable.
