### PR TITLE
Added side-by-side view and component selector to sprint compare

### DIFF
--- a/model.py
+++ b/model.py
@@ -67,7 +67,7 @@ def compare_sprints(db, *sprints, **query):
         A helper function that hydrates database results into a collection of
         objects
         """
-        return {TestResult(sprint=sprint, **rec) for rec in db.get_test_results(sprint, **query)}
+        return set([TestResult(sprint=sprint, **rec) for rec in db.get_test_results(sprint, **query)])
 
     ressets = {}
     result = {}
@@ -82,8 +82,8 @@ def compare_sprints(db, *sprints, **query):
         # from elsewhere.
         #
         othersprints = [x for x in sprints if x != sprint]
-        others = {x for key in othersprints for x in ressets[key]}
-        result[sprint] = {x for x in ressets[sprint] if x not in others}
+        others = set([x for key in othersprints for x in ressets[key]])
+        result[sprint] = set([x for x in ressets[sprint] if x not in others])
     return result
 
 def common_results(db, *sprints, **query):
@@ -96,7 +96,7 @@ def common_results(db, *sprints, **query):
         objects
         """
         result = db.get_test_results(sprint, **query)
-        return {TestResult(sprint=sprint, **rec) for rec in result}
+        return set([TestResult(sprint=sprint, **rec) for rec in result])
 
     ressets = {}
     for sprint in sprints:
@@ -104,7 +104,7 @@ def common_results(db, *sprints, **query):
 
     sprint = sprints[0]
     othersprints = sprints[1:]
-    others = {x for key in othersprints for x in ressets[key]}
+    others = set([x for key in othersprints for x in ressets[key]])
     result = others.intersection(ressets[sprint])
 
     return result

--- a/server.py
+++ b/server.py
@@ -27,7 +27,6 @@ def get_db(project=None):
 
 
 def get_manual_db(project=None):
-
     if project:
         return AggregationDB(hostname=server.config['db_hostname'],
                              port=server.config['db_port'],
@@ -88,6 +87,50 @@ def compare_sprints_action(project, sprint):
         comparison_sizes=comparison_sizes,
         common_results=common_size,
         grouped_common_results=grouped_common_results,
+        comparison=comparison
+    )
+
+@server.route('/side-by-side/<project>/<sprint>')
+def sidebyside_sprints_action(project, sprint):
+    db = get_db(project)
+
+    projects = db.get_project_names()
+    if project not in projects:
+        return 'I don\'t have results for this project... Sorry... :/', 404
+
+    sprints = db.get_sprint_names()
+    if sprint not in sprints:
+        return 'I don\'t have results for this sprint... Sorry... :/', 404
+    sprints.remove(sprint)
+
+    mysprints = request.args.getlist('sprint')
+    mysprints.append(sprint)
+    common = common_results(db, *mysprints, result={'$in': ('failed', 'error')})
+    common_size = len(common)
+    comparison = compare_sprints(db, *mysprints, result={'$in': ('failed', 'error') })
+    comparison_length = sum([len(x) for x in comparison.itervalues()])
+    comparison_sizes = {}
+    suites = set()
+    for s in comparison.iterkeys():
+        comparison_sizes[s] = len(comparison[s])
+        grouped = regroup_results(comparison[s], 'suite')
+        groupedres = {}
+        for k, v in grouped:
+            groupedres[k[0]] = list(v)
+            suites.add(k[0])
+        comparison[s] = groupedres
+
+    return render_template(
+        'sidebyside.html',
+        project=project,
+        projects=projects,
+        sprints=sprints,
+        sprint=sprint,
+        suites=list(suites),
+        compared_sprints=mysprints,
+        comparison_length=comparison_length,
+        comparison_sizes=comparison_sizes,
+        common_results=common_size,
         comparison=comparison
     )
 

--- a/server.py
+++ b/server.py
@@ -111,14 +111,31 @@ def sidebyside_sprints_action(project, sprint):
     comparison_length = sum([len(x) for x in comparison.itervalues()])
     comparison_sizes = {}
     suites = set()
-    for s in comparison.iterkeys():
+    component_classes = {}
+    components_by_suites = {}
+    components = {}
+    sprint_ctr = 0
+    component_ctr = 0
+    for s in comparison.iterkeys(): # s = sprint
         comparison_sizes[s] = len(comparison[s])
         grouped = regroup_results(comparison[s], 'suite')
         groupedres = {}
-        for k, v in grouped:
+        for k, v in grouped: # k = (suite)
             groupedres[k[0]] = list(v)
             suites.add(k[0])
+            # Build CSS classes for (sprint, component)
+            for i in groupedres[k[0]]:
+                if component_classes.get(i.sprint) is None: component_classes[i.sprint] = {}
+                curr_component = components.get(i.component)
+                if curr_component is None:
+                    component_ctr += 1
+                    components[i.component] = component_ctr
+                    curr_component = component_ctr
+                component_classes[s][i.component] = 's_{0}_c_{1}'.format(sprint_ctr, curr_component)
+                if components_by_suites.get(i.suite) is None: components_by_suites[i.suite] = {}
+                components_by_suites[i.suite][i.sprint] = 's_{0}_c_{1}'.format(sprint_ctr, curr_component)
         comparison[s] = groupedres
+        sprint_ctr += 1
 
     return render_template(
         'sidebyside.html',
@@ -131,7 +148,10 @@ def sidebyside_sprints_action(project, sprint):
         comparison_length=comparison_length,
         comparison_sizes=comparison_sizes,
         common_results=common_size,
-        comparison=comparison
+        comparison=comparison,
+        component_classes=component_classes,
+        components_by_suites=components_by_suites,
+        component_classes_json=json.dumps(component_classes)
     )
 
 @server.route('/<project>/<sprint>')

--- a/static/files/css/custom.css
+++ b/static/files/css/custom.css
@@ -32,3 +32,7 @@
     outline: none;
     color: #333;
 }
+
+.panel-comparison-testsuite {
+    display: none;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -9,7 +9,6 @@
 
         <link type="text/css" href={{ url_for('static', filename='files/css/bootstrap.min.css') }} rel="stylesheet">
         <link type="text/css" href={{ url_for('static', filename='files/css/custom.css') }} rel="stylesheet">
-
     </head>
 
     <body>

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% from 'macros.html' import render_test_results %}
+{% from 'macros.html' import render_grouped_test_results %}
 {% block menu %}
 
         <li class="dropdown">
@@ -54,31 +54,31 @@
             {% endfor %}
     </h2>
     {% endif %}
-    {% if common_results %}
-        <div class="panel panel-default">
-        <div class="panel-heading"><h4>{{ common_results }} failures common to these sprints
-            <button class="btn btn-info btn-sm" data-toggle="collapse" data-target="#commonFailures" role="button" type="button">toggle</button>
-        </h4></div>
-        <div class="panel-body collapse" id="commonFailures">
-            {{ render_test_results(grouped_common_results) }}
-        </div>
-        </div>
-    {% else %}
-        <div class="well well-lg">There are no results common to these sprints.</div>
-    {% endif %}
+
     {% if not comparison_length %}
         <div class="well well-lg">There are no failures unique to sprints being compared.</div>
     {% else %}
         {% for spr in comparison %}
             <div class="panel panel-default">
-                <div class="panel-heading"><h4>
+                <div class="panel-heading"><h5>
                     {{ comparison_sizes[spr] }} Failures unique to <a href="/{{ project }}/{{ spr }}">{{ spr }}</a>
                     <button class="btn btn-info btn-sm" data-toggle="collapse" data-target="#uniques_{{ loop.index }}" role="button" type="button">toggle</button>
-                </h4></div>
-                <div class="panel-body collapse in" id="uniques_{{ loop.index }}">
-                    {{ render_test_results(comparison[spr]) }}
-                </div>
+                </h5></div>
+                {{ render_grouped_test_results(comparison[spr], False, 'uniques_'+(loop.index|string)) }}
             </div>
         {% endfor %}
     {% endif %}
+
+    {% if common_results %}
+        <div class="panel panel-default">
+        <div class="panel-heading"><h5>{{ common_results }} failures common to these sprints
+            <button class="btn btn-info btn-sm" data-toggle="collapse" data-target="#commonFailures" role="button" type="button">toggle</button>
+        </h5></div>
+        {{ render_grouped_test_results(grouped_common_results, True, "commonFailures") }}
+        </div>
+    {% else %}
+        <div class="well well-lg">There are no results common to these sprints.</div>
+    {% endif %}
+
+
 {% endblock %}

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -43,10 +43,10 @@
 
 {% block body %}
     {% if compared_sprints|length == 1 %}
-        <h2>Comparing <a href="/{{ project }}/{{ sprint }}">{{ sprint }}</a>
+        <h4>Comparing <a href="/{{ project }}/{{ sprint }}">{{ sprint }}</a>
             with
             <a href="/{{ project }}/{{ compared_sprints[0] }}">{{ compared_sprints[0] }}</a>
-        </h2>
+        </h4>
     {% else %}
     <h2>Comparing <a href="/{{ project }}/{{ sprint }}">{{ sprint }}</a> with
             {% for s in compared_sprints %}

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -6,17 +6,17 @@
             list-group-item-success
         {% endif %}
     " data-toggle="modal" data-target="#ModalError{{ result.sprint_normalized }}{{ result.component_normalized }}{{ result.suite }}{{ result.test_id }}">
-            <h4 class="list-group-item-heading">
-                <small><span class="label
+            <h5 class="list-group-item-heading">
+                <span class="label
                     {% if result.result in ('failed', 'error') %}
                     label-danger
                     {% elif result.result == 'success' %}
                     label-success
                     {% else %}
                     label-default
-                    {% endif %}">{{ result.result }}</span></small>
+                    {% endif %}">{{ result.result }}</span>
                 {{ result.test_id }}
-            </h4>
+            </h5>
             <p class="list-group-item-text">{{ result.title }}</p>
             {% if result.attributes %}
                 <p class="list-group-item-text text-right">
@@ -45,18 +45,25 @@
 
 {% endmacro %}
 
-{% macro render_test_results(results) %}
+{% macro render_grouped_test_results(results, collapse, id) %}
+    <ul class="list-group collapse {% if not collapse %}in{% endif %}" id="{{ id }}">
     {% for component in results|sort %}
-        <h3 class="head-component">{{ component }}</h3>
+        <li class="list-group-item">
+        <h4 class="list-group-item-heading">{{ component }}</h4>
         {% for suite in results[component]|sort %}
             <div class="panel panel-default">
-            <div class="panel-heading"><h4>{{ suite }}</h4></div>
-            <div class="list-group">
-            {% for result in results[component][suite] %}
-                {{ testresult(result) }}
-            {% endfor %}
-            </div>
+            <div class="panel-heading">{{ suite }}</div>
+            {{ render_test_results(results[component][suite]) }}
             </div>
         {% endfor %}
+        </li>
     {% endfor %}
+{% endmacro %}
+
+{% macro render_test_results(results) %}
+    <div class="list-group">
+    {% for result in results %}
+        {{ testresult(result) }}
+    {% endfor %}
+    </div>
 {% endmacro %}

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "macros.html" import render_test_results %}
+{% from "macros.html" import render_grouped_test_results %}
 {% block customjs %}
 
 <script type="text/javascript">
@@ -176,7 +176,7 @@
         </ul>
 
         {% if failed_tests %}
-        <form action="/compare/{{ project }}/{{ sprint }}" method="GET">
+        <form action="/side-by-side/{{ project }}/{{ sprint }}" method="GET">
             <div class="panel panel-default">
                 <div class="panel-heading">
                     Compare Sprints
@@ -202,7 +202,7 @@
         <br>
 
         <div style="display:none" id="failedTestsList">
-            {{ render_test_results(failed_tests) }}
+            {{ render_grouped_test_results(failed_tests, False, "") }}
         </div>
 
         {% endif %}

--- a/templates/sidebyside.html
+++ b/templates/sidebyside.html
@@ -44,11 +44,11 @@
 {% block body %}
 
     {# Heading #}
-    <h2>Comparing <a href="/{{ project }}/{{ sprint }}">{{ sprint }}</a> with
+    <h4>Comparing <a href="/{{ project }}/{{ sprint }}">{{ sprint }}</a> with
             {% for s in compared_sprints %}
                 {% if s != sprint %}<a href="/{{ project }}/{{ s }}">{{ s }}</a>{% if loop.index < (compared_sprints|length - 1) %},{% endif %}{% endif %}
             {% endfor %}
-    </h2>
+    </h4>
 
     {# Component selector #}
     <div class="panel panel-default">

--- a/templates/sidebyside.html
+++ b/templates/sidebyside.html
@@ -1,0 +1,178 @@
+{% extends 'base.html' %}
+{% from 'macros.html' import render_test_results, render_grouped_test_results %}
+{% block menu %}
+
+        <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                {{ project }} <b class="caret"></b>
+            </a>
+
+            <ul class="dropdown-menu">
+
+                {% for p in projects%}
+
+                <li><a href="/{{ p }}">{{ p }}</a></li>
+
+                {% endfor %}
+
+            </ul>
+        </li>
+
+        <li class="dropdown">
+
+            {% if sprints %}
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                    {{ sprint }} <b class="caret"></b>
+                </a>
+
+                <ul class="dropdown-menu">
+
+                    {% for s in sprints%}
+                    <li><a href="/{{ project }}/{{ s }}">{{ s }}</a></li>
+                    {% endfor %}
+
+                </ul>
+            {% else %}
+                <a href="/{{ project }}/{{ sprint }}">{{ sprint }} </a>
+            {% endif %}
+
+        </li>
+
+{% endblock %}
+
+
+{% block body %}
+
+    {# Heading #}
+    <h2>Comparing <a href="/{{ project }}/{{ sprint }}">{{ sprint }}</a> with
+            {% for s in compared_sprints %}
+                {% if s != sprint %}<a href="/{{ project }}/{{ s }}">{{ s }}</a>{% if loop.index < (compared_sprints|length - 1) %},{% endif %}{% endif %}
+            {% endfor %}
+    </h2>
+
+    {# Component selector #}
+    <div class="panel panel-default">
+        <div class="panel-heading">Select Components
+            <button
+                    type="button"
+                    class="btn btn-info btn-sm" data-toggle="collapse"
+                    data-target="#componentSelector">toggle</button></div>
+        <table class="table collapse in" id="componentSelector">
+            <thead>
+                <tr>
+                    {% for s in compared_sprints %}
+                        <th>{{ s }}</th>
+                    {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    {% for s in compared_sprints %}
+                        <td>
+                            <div class="list-group" data-sprint="{{ s }}">
+                                {% for c, cl in component_classes[s].iteritems() %}
+                                    <a class="list-group-item component-selector-item"
+                                       data-cls="{{ cl }}">{{ c }}</a>
+                                {% endfor %}
+                            </div>
+                        </td>
+                    {% endfor %}
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+    {# Actual testsuites #}
+    {% for suite in suites|sort %}
+        <div class="panel panel-default panel-comparison-testsuite
+        {% for s in compared_sprints %}
+            {% if components_by_suites[suite][s] %}
+                {{ components_by_suites[suite][s] }}
+            {% endif %}
+        {% endfor %}" data-suite="{{ suite }}">
+            <div class="panel-heading">
+                {{ suite }}
+                {% for s in compared_sprints %}
+                    <span class="label {% if comparison[s][suite]|length %}label-danger{% else %}label-default{% endif %}">{{
+                        comparison[s][suite]|length|int
+                    }}</span>&nbsp;
+                {% endfor %}
+            </div>
+            <div class="panel-body" style="overflow: scroll">
+                <table class="table table-responsive">
+                    <thead>
+                        <tr>
+                        {% for s in compared_sprints %}
+                            <th style="min-width: 380px; max-width: 380px;">{{ s }}</th>
+                        {% endfor %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            {% for s in compared_sprints %}
+                                <td style="min-width: 380px; max-width: 380px;">
+                                {% if comparison[s][suite] %}
+                                    {{ render_test_results(comparison[s][suite]) }}
+                                {% endif %}
+                                </td>
+                            {% endfor %}
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {% endfor %}
+
+{% endblock %}
+
+{% block customjs %}
+    <script type="text/javascript">
+        var component_classes = {{ component_classes_json|safe }};
+        var selectedClasses = {};
+
+        var refresh_components = function() {
+            $('.panel-comparison-testsuite').hide();
+            var components = [];
+            for (var i in selectedClasses) {
+                components.push('.'+i);
+            }
+            if (components.length == 0) {
+                return;
+            }
+            var selector = components.join(',');
+            window.location = '#'+selector;
+            $(selector).show();
+        };
+
+        var select_cmp_selector = function(elem) {
+            var already_selected = !elem.hasClass('list-group-item-success');
+            elem.closest('.list-group').find('a.list-group-item-success').each(function(){
+                var el = $(this);
+                var cls = el.attr('data-cls');
+                el.removeClass('list-group-item-success');
+                delete selectedClasses[cls];
+            });
+            if (already_selected) {
+                elem.addClass('list-group-item-success');
+                selectedClasses[elem.attr('data-cls')] = true;
+            }
+            refresh_components();
+        };
+
+        $(document).ready(function(){
+            var s = window.location.hash.replace(/^#/, '');
+            console.log(s);
+            $(s).show();
+            var selectors = s.split(',');
+            for (var i in selectors) {
+                var curated = selectors[i].replace(/^\./, '');
+                $("a[data-cls='"+curated+"']").addClass('list-group-item-success');
+            }
+        });
+
+        $('a.component-selector-item').click(function(){
+            select_cmp_selector($(this));
+        });
+    </script>
+{% endblock %}
+


### PR DESCRIPTION
- Bookmarkable
- Still able to compare multiple sprints
- Component selection is "OR"-based: suites are shown that have failures in any of the selected components.
- Made comparison headers less ugly

Clartifying that last item: if selecting suites that have failures in ALL selected sprints, the suites that were fixed, or suites that only started failing in the newer sprint, won't get shown. 
