### PR TITLE
More fixes to sprint compare

### DIFF
--- a/static/files/css/custom.css
+++ b/static/files/css/custom.css
@@ -34,9 +34,23 @@
 }
 
 .panel-comparison-testsuite {
+     display: none; 
+}
+
+.counter-results-unique {
     display: none;
 }
 
 th.no-tests-were-run {
     color: #aaa;
+}
+
+table.results-comparison td,
+table.results-comparison th
+{
+    width: 48%;
+}
+
+.results-comparison-panel {
+    overflow-x: scroll;
 }

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,20 +1,29 @@
+{% macro _labelclass(result) %}
+    {% if result.result in ('failed', 'error') %}
+        label-danger
+    {% elif result.result == 'passed' %}
+        label-success
+    {% else %}
+        label-default
+    {% endif %}
+{% endmacro %}
+
+{% macro _itemclass(result) %}
+    {% if result.result in ('failed', 'error') %}
+        list-group-item-danger
+    {% elif result.result == 'passed' %}
+        list-group-item-success
+    {% endif %}
+{% endmacro %}
+
 {% macro testresult(result) %}
-    <a class="list-group-item
-        {% if result.result in ('failed', 'error') %}
-            list-group-item-danger
-        {% elif result.result == 'passed' %}
-            list-group-item-success
-        {% endif %}
-    " data-toggle="modal" data-target="#ModalError{{ result.sprint_normalized }}{{ result.component_normalized }}{{ result.suite }}{{ result.test_id }}">
+    <a class="list-group-item test-result {{ _itemclass(result) }} {% if result.unique%}unique{% endif %} "
+       data-toggle="modal" data-target="#ModalError{{ result.sprint_normalized }}{{ result.component_normalized }}{{ result.suite }}{{ result.test_id }}">
             <h5 class="list-group-item-heading">
-                <span class="label
-                    {% if result.result in ('failed', 'error') %}
-                    label-danger
-                    {% elif result.result == 'passed' %}
-                    label-success
-                    {% else %}
-                    label-default
-                    {% endif %}">{{ result.result }}</span>
+                <span class="label {{ _labelclass(result) }}">{{ result.result }}</span>
+                {% if result.unique %}
+                    <span class="label {{ _labelclass(result) }}">&#x2022;</span>
+                {% endif %}
                 {{ result.test_id }}
             </h5>
             <p class="list-group-item-text">{{ result.title }}</p>
@@ -62,7 +71,7 @@
 
 {% macro render_test_results(results) %}
     <div class="list-group">
-    {% for result in results %}
+    {% for result in results|sort(attribute='test_id') %}
         {{ testresult(result) }}
     {% endfor %}
     </div>

--- a/templates/sidebyside.html
+++ b/templates/sidebyside.html
@@ -1,41 +1,46 @@
 {% extends 'base.html' %}
 {% from 'macros.html' import render_test_results, render_grouped_test_results %}
+
+{% macro component_badges(results) %}
+    {% set badges = {} %}
+    {% for r in results %}
+        {% set dummy = badges.setdefault(r.component, 1) %}
+    {% endfor %}
+    {% for k in badges.keys()|sort %}
+        <span class="label label-default">{{ k }}</span>
+    {% endfor %}
+{% endmacro %}
+
 {% block menu %}
 
         <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                 {{ project }} <b class="caret"></b>
             </a>
-
             <ul class="dropdown-menu">
-
                 {% for p in projects%}
-
-                <li><a href="/{{ p }}">{{ p }}</a></li>
-
+                    <li><a href="/{{ p }}">{{ p }}</a></li>
                 {% endfor %}
-
             </ul>
         </li>
 
         <li class="dropdown">
-
             {% if sprints %}
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                     {{ sprint }} <b class="caret"></b>
                 </a>
-
                 <ul class="dropdown-menu">
-
                     {% for s in sprints%}
                     <li><a href="/{{ project }}/{{ s }}">{{ s }}</a></li>
                     {% endfor %}
-
                 </ul>
             {% else %}
                 <a href="/{{ project }}/{{ sprint }}">{{ sprint }} </a>
             {% endif %}
+        </li>
 
+        <li>
+            <a id="toggleUniques" data-value="unique" href="javascript:void(0)">Uniquel Results</a>
         </li>
 
 {% endblock %}
@@ -70,9 +75,14 @@
                     {% for s in compared_sprints %}
                         <td>
                             <div class="list-group" data-sprint="{{ s }}">
-                                {% for c, cl in component_classes[s].iteritems() %}
+                                {% for c in component_stats[s].keys()|sort() %}
+                                    {% if component_stats[s][c] %}
                                     <a class="list-group-item component-selector-item"
-                                       data-cls="{{ cl }}">{{ c }}</a>
+                                       data-cls="{{ components_css[(s,c)] }}">
+                                        <span class="label label-danger">{{ component_stats[s][c] }}</span>
+                                        {{ c }}
+                                    </a>
+                                    {% endif %}
                                 {% endfor %}
                             </div>
                         </td>
@@ -83,68 +93,127 @@
     </div>
 
     {# Actual testsuites #}
-    {% for suite in suites|sort %}
-        {% if lengths_by_suite[suite] %}
-        <div class="panel panel-default panel-comparison-testsuite
-        {% for s in compared_sprints %}
-            {% if components_by_suites[suite][s] %}
-                {{ components_by_suites[suite][s] }}
-            {% endif %}
-        {% endfor %}" data-suite="{{ suite }}">
-            <div class="panel-heading">
-                {{ suite }}
+    <div class="panel panel-default results-comparison-panel">
+    <table class="table results-comparison">
+        <thead>
+            <tr>
                 {% for s in compared_sprints %}
-                    <span class="label {% if comparison[s][suite]|length %}label-danger{% else %}label-default{% endif %}">{{
-                        comparison[s][suite]|length|int
-                    }}</span>&nbsp;
+                <th>{{ s }}</th>
                 {% endfor %}
-            </div>
-            <div class="panel-body" style="overflow: scroll">
-                <table class="table table-responsive">
-                    <thead>
-                        <tr>
-                        {% for s in compared_sprints %}
-                            <th style="min-width: 380px; max-width: 380px;" {% if not component_names_by_suites[suite][s] %}class="no-tests-were-run"{% endif %}>{{ s }}  <span class="label label-default">{{ component_names_by_suites[suite][s] }}</span></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                {% for s in compared_sprints %}
+                <td data-sprint="{{ s }}">
+                    {% for component in comparison[s].keys()|sort %}
+                    <div data-component="{{ component }}" class="panel panel-default panel-comparison-testsuite {{ components_css[(s, component)] }}">
+                        <div class="panel-heading">
+                            {{ component }}
+                        </div>
+                        <div class="panel-body">
+                        {% for suite, results in comparison[s][component].iteritems() %}
+                        <div class="comparison-testsuite" data-suite="{{ suite }}">
+                            <h5>{{ suite }}</h5>
+                            <ul class="list-group">
+                                {{ render_test_results(results) }}
+                            </ul>
+                        </div>
                         {% endfor %}
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            {% for s in compared_sprints %}
-                                <td style="min-width: 380px; max-width: 380px;">
-                                {% if comparison[s][suite] %}
-                                    {{ render_test_results(comparison[s][suite]) }}
-                                {% endif %}
-                                </td>
-                            {% endfor %}
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        {% endif %}
-    {% endfor %}
+                        </div>
+                    </div>
+                    {% endfor %}
+                </td>
+                {% endfor %}
+            </tr>
+        </tbody>
+    </table>
+    </div>
+
 
 {% endblock %}
 
 {% block customjs %}
     <script type="text/javascript">
-        var component_classes = {{ component_classes_json|safe }};
         var selectedClasses = {};
+        var update_testsuites = function() {
+            $('.comparison-testsuite').each(function(){
+                if ($(this).find('.shown').length == 0) {
+                    $(this).hide();
+                } else {
+                    $(this).show();
+                }
+            });
+        }
 
-        var refresh_components = function() {
-            $('.panel-comparison-testsuite').hide();
+        var update_unique = function() {
+            var elem = $('#toggleUniques');
+            if (elem.attr('data-value') == 'unique') {
+                elem.html('Unique Results');
+                $('.test-result').hide();
+                $('.test-result').removeClass('shown');
+                $('.test-result.unique').show();
+                $('.test-result.unique').addClass('shown');
+                $('.counter-results-unique').show();
+                $('.counter-results-all').hide();
+            } else {
+                elem.html('All Results'); 
+                $('.test-result').show();
+                $('.test-result').addClass('shown');
+                $('.counter-results-unique').hide();
+                $('.counter-results-all').show();
+            }
+            update_testsuites();
+            update_location_hash();
+        };
+
+
+        $('#toggleUniques').click(function(){
+            var elem = $(this);
+            if (elem.attr('data-value') == 'all') {
+                elem.attr('data-value', 'unique');
+            } else {
+                elem.attr('data-value', 'all');
+            }
+            update_unique();
+        });
+
+        var update_location_hash = function() {
+            var hashpieces = {
+                'components': '',
+                'show': ''
+            };
             var components = [];
             for (var i in selectedClasses) {
                 components.push('.'+i);
             }
-            if (components.length == 0) {
-                window.location.hash = '';
-                return;
+            if (components.length > 0) {
+                hashpieces['components'] = components.join(',');
             }
-            var selector = components.join(',');
-            window.location = '#'+selector;
-            $(selector).show();
+            hashpieces['show'] = $('#toggleUniques').attr('data-value');
+    
+            var s = "";
+            for (var i in hashpieces) {
+                if (!hashpieces[i]) {
+                    continue;
+                }
+                var elem = i + "=" + hashpieces[i];
+                s += elem + ';';
+            }
+    
+            console.log(s);
+            window.location = '#'+s;
+        };
+
+        var refresh_components = function() {
+            $('.panel-comparison-testsuite').hide();
+            for (var i in selectedClasses) {
+                var selector = '.' + i;
+                $(selector).show();
+                $(selector).addClass('shown');
+            }
+            update_testsuites();
+            update_location_hash();
         };
 
         var select_cmp_selector = function(elem) {
@@ -160,14 +229,31 @@
         };
 
         $(document).ready(function(){
-            var s = window.location.hash.replace(/^#/, '');
-            $(s).show();
-            var selectors = s.split(',');
-            for (var i in selectors) {
-                var curated = selectors[i].replace(/^\./, '');
-                selectedClasses[curated] = true;
-                $("a[data-cls='"+curated+"']").addClass('list-group-item-success');
+            var hsh = window.location.hash.replace(/^#/, '');
+            if (!hsh) {
+                refresh_components();
+                update_unique();
+                return;
             }
+            var elems = hsh.split(';');
+            for (var i in elems) {
+                var piece = elems[i];
+                var tuple = piece.split('=');
+                if (tuple[0] == 'components') {
+                    var s = tuple[1];
+                    $(s).show();
+                    var selectors = s.split(',');
+                    for (var i in selectors) {
+                        var curated = selectors[i].replace(/^\./, '');
+                        selectedClasses[curated] = true;
+                        $("a[data-cls='"+curated+"']").addClass('list-group-item-success');
+                    }
+                } else if (tuple[0] == 'show') {
+                    $('#toggleUniques').attr('data-value', tuple[1]);
+                }
+            }
+            refresh_components();
+            update_unique();
         });
 
         $('a.component-selector-item').click(function(){


### PR DESCRIPTION
1. Results are keyed by component, too (fixes missing results)
2. There's possibility to see all failures vs unique failures (hopefully resolves discrepancies with regards to number of failures reported in main view vs comparison views)
3. Failures unique to the sprint are marked with a bullet badge so they can be distinguished (bullet meaning "happened only here")
