### PR TITLE
Fixes to comparison view:

### DIFF
--- a/model.py
+++ b/model.py
@@ -41,7 +41,8 @@ class TestResult(object):
         self.unique = False
 
     def __str__(self):
-        return "<TestResult(%s, %s, %s.%s) = %s>" % (
+        return "<%sTestResult(%s, %s, %s.%s) = %s>" % (
+            '*' if self.unique else '',
             self.sprint,
             self.component,
             self.suite,
@@ -50,7 +51,8 @@ class TestResult(object):
         )
 
     def __repr__(self):
-        return "<TestResult(%s, %s, %s.%s) = %s>" % (
+        return "<%sTestResult(%s, %s, %s.%s) = %s>" % (
+            '*' if self.unique else '',
             self.sprint,
             self.component,
             self.suite,
@@ -90,6 +92,10 @@ class TestResultsComparison(object):
         self._iter = None
         lsuites = set([x.suite for x in self.left])
         rsuites = set([x.suite for x in self.right])
+        self.l_components = [
+            sorted(list(set([x.component for x in self.left]))),
+            sorted(list(set([x.component for x in self.right]))),
+        ]
         self.suites = sorted(list(lsuites.union(rsuites)))
         self.left_by_suite = {}
         self.right_by_suite = {}
@@ -116,8 +122,8 @@ class TestResultsComparison(object):
             self.right_by_suite[suite] = list(uniqright)
             self.all_left_by_suite[suite] = list(onleft)
             self.all_right_by_suite[suite] = list(onright)
-            [setattr(x, 'unique', True) for x in self.all_left_by_suite[suite] if x in uniqleft]
-            [setattr(x, 'unique', True) for x in self.all_right_by_suite[suite] if x in uniqright]
+            [setattr(x, 'unique', True) for x in self.all_left_by_suite[suite] if x not in onright]
+            [setattr(x, 'unique', True) for x in self.all_right_by_suite[suite] if x not in onleft]
             self.unique_left += self.left_by_suite[suite]
             self.unique_right += self.right_by_suite[suite]
 
@@ -127,10 +133,7 @@ class TestResultsComparison(object):
         return list(l), list(r)
 
     def used_components(self, sprint):
-        current = self.unique_left
-        if sprint != 0:
-            current = self.unique_right
-        return sorted(list(set([x.component for x in current])))
+        return copy.copy(self.l_components[sprint])
 
     def __iter__(self):
         for suite in self.suites:

--- a/model.py
+++ b/model.py
@@ -110,10 +110,14 @@ class TestResultsComparison(object):
         for suite in self.suites:
             onleft = set([x for x in self.left if x.suite == suite])
             onright = set([x for x in self.right if x.suite == suite])
-            self.left_by_suite[suite] = list(onleft.difference(onright))
-            self.right_by_suite[suite] = list(onright.difference(onleft))
+            uniqleft = onleft.difference(onright)
+            uniqright = onright.difference(onleft)
+            self.left_by_suite[suite] = list(uniqleft)
+            self.right_by_suite[suite] = list(uniqright)
             self.all_left_by_suite[suite] = list(onleft)
             self.all_right_by_suite[suite] = list(onright)
+            [setattr(x, 'unique', True) for x in self.all_left_by_suite[suite] if x in uniqleft]
+            [setattr(x, 'unique', True) for x in self.all_right_by_suite[suite] if x in uniqright]
             self.unique_left += self.left_by_suite[suite]
             self.unique_right += self.right_by_suite[suite]
 
@@ -139,6 +143,11 @@ class TestResultsComparison(object):
 
     def reset(self):
         self._iter = None
+
+    def iter_all(self):
+        for suite in self.suites:
+            yield suite, self.all_left_by_suite[suite], self.all_right_by_suite[suite]
+
 
 
 def common_results(db, *sprints, **query):

--- a/static/files/css/custom.css
+++ b/static/files/css/custom.css
@@ -48,9 +48,10 @@ th.no-tests-were-run {
 table.results-comparison td,
 table.results-comparison th
 {
-    width: 48%;
+    width: 47%;
 }
 
 .results-comparison-panel {
     overflow-x: scroll;
 }
+

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -11,12 +11,12 @@
 
 {% macro testresult(result, classes=None) %}
 {% filter trim %}
-    <a class="list-group-item test-result {{ _itemclass(result) }}{% if classes %} {{ classes }}{% endif %}{% if result.unique%} unique{% endif %}"
+    <a class="list-group-item test-result {{ _itemclass(result) }}{% if classes %} {{ classes }}{% endif %} {% if result.unique%}unique{% else %}non-unique{% endif %}"
        data-toggle="modal" data-target="#ModalError{{ result.sprint_normalized }}{{ result.component_normalized }}{{ result.suite }}{{ result.test_id }}">
             <h5 class="list-group-item-heading">
                 <span class="label {{ _labelclass(result) }}">{{ result.result }}</span>
                 {% if result.unique %}
-                    <span class="label {{ _labelclass(result) }}">&#x2022;</span>
+                    <span class="label {{ _labelclass(result) }}"><i class="glyphicon glyphicon-star"></i></span>
                 {% endif %}
                 {{ result.test_id }}
             </h5>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,23 +1,17 @@
-{% macro _labelclass(result) %}
-    {% if result.result in ('failed', 'error') %}
-        label-danger
-    {% elif result.result == 'passed' %}
-        label-success
-    {% else %}
-        label-default
-    {% endif %}
-{% endmacro %}
+{% macro _labelclass(result) %}{%
+    if result.result in ('failed', 'error') %}label-danger{% 
+       elif result.result == 'passed' %}label-success{%
+       else %}label-default{% endif
+%}{% endmacro %}
 
-{% macro _itemclass(result) %}
-    {% if result.result in ('failed', 'error') %}
-        list-group-item-danger
-    {% elif result.result == 'passed' %}
-        list-group-item-success
-    {% endif %}
-{% endmacro %}
+{% macro _itemclass(result) %}{% 
+    if result.result in ('failed', 'error') %}list-group-item-danger{% 
+       elif result.result == 'passed' %}list-group-item-success{% endif
+%}{% endmacro %}
 
-{% macro testresult(result) %}
-    <a class="list-group-item test-result {{ _itemclass(result) }} {% if result.unique%}unique{% endif %} "
+{% macro testresult(result, classes=None) %}
+{% filter trim %}
+    <a class="list-group-item test-result {{ _itemclass(result) }}{% if classes %} {{ classes }}{% endif %}{% if result.unique%} unique{% endif %}"
        data-toggle="modal" data-target="#ModalError{{ result.sprint_normalized }}{{ result.component_normalized }}{{ result.suite }}{{ result.test_id }}">
             <h5 class="list-group-item-heading">
                 <span class="label {{ _labelclass(result) }}">{{ result.result }}</span>
@@ -51,7 +45,7 @@
             </div>
         </div>
     </div>
-
+{% endfilter %}
 {% endmacro %}
 
 {% macro render_grouped_test_results(results, collapse, id) %}

--- a/templates/results.html
+++ b/templates/results.html
@@ -176,26 +176,22 @@
         </ul>
 
         {% if failed_tests %}
-        <form action="/side-by-side/{{ project }}/{{ sprint }}" method="GET">
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                    Compare Sprints
-                    <button type="button" class="btn btn-info btn-sm" data-toggle="collapse" role="button" data-target="#compareSprints">toggle</button>
-                    <button type="submit" id="compareSubmit" class="btn btn-sm btn-success">Go <i class="glyphicon glyphicon-chevron-right"></i></button>
-                    <span class="badge" id="comparisonCounter"></span>
-                </div>
-                <div class="collapse list-group" id="compareSprints">
-                    {% for s in sprints %}
-                        {% if s != sprint %}
-                            <a class="cmprow list-group-item container">
-                                <span class="col-sm-1"><input type="checkbox" name="sprint" value="{{ s }}"></span>
-                                <span class="col">{{ s }}</span>
-                            </a>
-                        {% endif %}
-                    {% endfor %}
-                </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                Compare Sprints
+                <button type="button" class="btn btn-info btn-sm" data-toggle="collapse" role="button" data-target="#compareSprints">toggle</button>
+                <span class="badge" id="comparisonCounter"></span>
             </div>
-        </form>
+            <div class="collapse list-group" id="compareSprints">
+                {% for s in sprints %}
+                    {% if s != sprint %}
+                        <a class="cmprow list-group-item container" href="/side-by-side/{{ project }}/{{ sprint }}/{{ s }}">
+                            {{ s }}
+                        </a>
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
 
 
 

--- a/templates/sidebyside.html
+++ b/templates/sidebyside.html
@@ -29,6 +29,11 @@
             </ul>
         </li>
         {% endfor %}
+        <li><p class="navbar-btn" >
+            <a class="btn btn-default" id="unique-switcher" data-value="all"><i class="glyphicon glyphicon-star-empty"></i> <span>All Results</span></a>
+            </p>
+        </li>
+
 {% endblock %}
 
 
@@ -95,6 +100,15 @@
     $(document).ready(function(){
         var window_parameters = {
         };
+        function update_unique_button() {
+            var el = $('#unique-switcher');
+            if (window_parameters['show'] == 'unique') {
+                el.attr('data-value', 'unique');
+                el.find('i.glyphicon').removeClass('glyphicon-star-empty').addClass('glyphicon-star');
+                el.find('span').html('Unique Results');
+                hide_invisible();
+            }
+        }
         $('.component-selector').click(function(e){
             e.preventDefault();
             var ul = $(this).closest('ul');
@@ -109,15 +123,35 @@
         });
         function select_components(left, right) {
             var selector = 'table.results-comparison a.'+left+', table.results-comparison a.'+right;
-            console.log(selector);
+            if (window_parameters['show'] == 'unique') {
+                selector = 'table.results-comparison a.unique.'+left+', table.results-comparison a.unique.'+right;
+            }
             $('.has-component').removeClass('visible');
             $(selector).addClass('visible');
         }
+        $('#unique-switcher').click(function(){
+            var el = $(this);
+            if (el.attr('data-value') == 'all') {
+                el.attr('data-value', 'unique');
+                window_parameters['show'] = 'unique';
+                el.find('span').html('Unique Results');
+                el.find('i.glyphicon').addClass('glyphicon-star').removeClass('glyphicon-star-empty');
+            } else {
+                el.attr('data-value', 'all');
+                el.find('i.glyphicon').addClass('glyphicon-star-empty').removeClass('glyphicon-star');
+                el.find('span').html('All Results');
+                window_parameters['show'] = 'all';
+            }
+            select_components(window_parameters['left'], window_parameters['right']);
+            hide_invisible();
+            refresh_history();
+        });
         function hide_invisible() {
             $('tr.suite-body').each(function(){
                 var coll = $(this).find('a.test-result.visible');
+                var collen = coll.length;
                 var s = $(this).attr('data-suite');
-                if (!coll.length) {
+                if (!collen) {
                     $('tr[data-suite="'+s+'"]').hide();
                 } else {
                     $('tr[data-suite="'+s+'"]').show();
@@ -138,6 +172,7 @@
                 var elements = current_component.split('=');
                 window_parameters[elements[0]] = elements[1] || true;
             }
+            update_unique_button();
         }
         function refresh_history() {
             var buffer = [];

--- a/templates/sidebyside.html
+++ b/templates/sidebyside.html
@@ -1,15 +1,7 @@
 {% extends 'base.html' %}
-{% from 'macros.html' import render_test_results, render_grouped_test_results %}
+{% from 'macros.html' import testresult %}
 
-{% macro component_badges(results) %}
-    {% set badges = {} %}
-    {% for r in results %}
-        {% set dummy = badges.setdefault(r.component, 1) %}
-    {% endfor %}
-    {% for k in badges.keys()|sort %}
-        <span class="label label-default">{{ k }}</span>
-    {% endfor %}
-{% endmacro %}
+{% macro css_component(comparison, sprint, component) %}s{{ sprint }}c{{ comparison.components[component] }}{% endmacro %}
 
 {% block menu %}
 
@@ -24,241 +16,146 @@
             </ul>
         </li>
 
+        {% for rl in ('left', 'right') %}
+        {% set idx = loop.index %}
         <li class="dropdown">
-            {% if sprints %}
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                    {{ sprint }} <b class="caret"></b>
-                </a>
-                <ul class="dropdown-menu">
-                    {% for s in sprints%}
-                    <li><a href="/{{ project }}/{{ s }}">{{ s }}</a></li>
-                    {% endfor %}
-                </ul>
-            {% else %}
-                <a href="/{{ project }}/{{ sprint }}">{{ sprint }} </a>
-            {% endif %}
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                <span>Select a component</span> <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu">
+                {% for p in comparison.used_components(idx - 1) %}
+                    <li><a class="component-selector {{ css_component(comparison, idx - 1, p) }}" data-sprint="{{ rl }}" data-cls="{{ css_component(comparison, idx - 1, p) }}" href="">{{ p }}</a></li>
+                {% endfor %}
+            </ul>
         </li>
-
-        <li>
-            <a id="toggleUniques" data-value="unique" href="javascript:void(0)">Uniquel Results</a>
-        </li>
-
+        {% endfor %}
 {% endblock %}
 
 
 {% block body %}
 
     {# Heading #}
-    <h4>Comparing <a href="/{{ project }}/{{ sprint }}">{{ sprint }}</a> with
-            {% for s in compared_sprints %}
-                {% if s != sprint %}<a href="/{{ project }}/{{ s }}">{{ s }}</a>{% if loop.index < (compared_sprints|length - 1) %},{% endif %}{% endif %}
-            {% endfor %}
+    <h4>
+        <a class="btn btn-default" href="/{{ project }}/{{ sprint }}"><i class="glyphicon glyphicon-arrow-left"></i> Back</a>
+        Comparing <a href="/{{ project }}/{{ sprint }}">{{ sprint }}</a> with <a href="/{{ project }}/{{ other_sprint }}">{{ other_sprint }}</a>
     </h4>
 
-    {# Component selector #}
-    <div class="panel panel-default">
-        <div class="panel-heading">Select Components
-            <button
-                    type="button"
-                    class="btn btn-info btn-sm" data-toggle="collapse"
-                    data-target="#componentSelector">toggle</button></div>
-        <table class="table collapse in" id="componentSelector">
-            <thead>
-                <tr>
-                    {% for s in compared_sprints %}
-                        <th>{{ s }}</th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    {% for s in compared_sprints %}
-                        <td>
-                            <div class="list-group" data-sprint="{{ s }}">
-                                {% for c in component_stats[s].keys()|sort() %}
-                                    {% if component_stats[s][c] %}
-                                    <a class="list-group-item component-selector-item"
-                                       data-cls="{{ components_css[(s,c)] }}">
-                                        <span class="label label-danger">{{ component_stats[s][c] }}</span>
-                                        {{ c }}
-                                    </a>
-                                    {% endif %}
-                                {% endfor %}
-                            </div>
-                        </td>
-                    {% endfor %}
-                </tr>
-            </tbody>
-        </table>
-    </div>
-
     {# Actual testsuites #}
-    <div class="panel panel-default results-comparison-panel">
     <table class="table results-comparison">
         <thead>
             <tr>
-                {% for s in compared_sprints %}
-                <th>{{ s }}</th>
-                {% endfor %}
+                <th>
+                    <span class="dropdown">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                            {{ sprint }} <b class="caret"></b>
+                        </a>
+                        <ul class="dropdown-menu">
+                            {% for s in sprints|sort %}
+                            {% if s != sprint %}
+                                <li><a href="/side-by-side/{{ project }}/{{ s }}/{{ other_sprint }}">{{ s }}</a></li>
+                            {% endif %}
+                            {% endfor %}
+                        </ul>
+                    </span>
+                </th>
+                <th>
+                    <span class="dropdown">
+                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                            {{ other_sprint }} <b class="caret"></b>
+                        </a>
+                        <ul class="dropdown-menu">
+                            {% for s in sprints|sort %}
+                            {% if s != other_sprint %}
+                                <li><a href="/side-by-side/{{ project }}/{{ sprint }}/{{ s }}">{{ s }}</a></li>
+                            {% endif %}
+                            {% endfor %}
+                        </ul>
+                    </span>                    
+                </th>
             </tr>
         </thead>
         <tbody>
-            <tr>
-                {% for s in compared_sprints %}
-                <td data-sprint="{{ s }}">
-                    {% for component in comparison[s].keys()|sort %}
-                    <div data-component="{{ component }}" class="panel panel-default panel-comparison-testsuite {{ components_css[(s, component)] }}">
-                        <div class="panel-heading">
-                            {{ component }}
-                        </div>
-                        <div class="panel-body">
-                        {% for suite, results in comparison[s][component].iteritems() %}
-                        <div class="comparison-testsuite" data-suite="{{ suite }}">
-                            <h5>{{ suite }}</h5>
-                            <ul class="list-group">
-                                {{ render_test_results(results) }}
-                            </ul>
-                        </div>
-                        {% endfor %}
-                        </div>
-                    </div>
-                    {% endfor %}
-                </td>
-                {% endfor %}
+            {% for suite, left, right in comparison %}{% if left|length + right|length > 0 %}
+            <tr class="suite-header" data-suite="{{ suite }}">
+                <th colspan="2">{{ suite }}</th>
             </tr>
+            <tr class="suite-body" data-suite="{{ suite }}">
+                <td class="list-group left-sprint">{% for result in left|sort(attribute='test_id') %}{{ testresult(result, 'has-component '~css_component(comparison, 0, result.component)) }}{% endfor %}</td>
+                <td class="list-group right-sprint">{% for result in right|sort(attribute='test_id') %}{{ testresult(result, 'has-component '~css_component(comparison, 1, result.component)) }}{% endfor %}</td>
+            </tr>
+            {% endif %}{% endfor %}
         </tbody>
     </table>
-    </div>
 
 
 {% endblock %}
 
 {% block customjs %}
     <script type="text/javascript">
-        var selectedClasses = {};
-        var update_testsuites = function() {
-            $('.comparison-testsuite').each(function(){
-                if ($(this).find('.shown').length == 0) {
-                    $(this).hide();
+    $(document).ready(function(){
+        var window_parameters = {
+        };
+        $('.component-selector').click(function(e){
+            e.preventDefault();
+            var ul = $(this).closest('ul');
+            var li = $(this).closest('li');
+            var a = ul.closest('li').find('.dropdown-toggle span');
+            a.html($(this).html());
+            var cls = $(this).attr('data-cls');
+            window_parameters[$(this).attr('data-sprint')] = cls;
+            select_components(window_parameters['left'], window_parameters['right']);
+            hide_invisible();
+            refresh_history();
+        });
+        function select_components(left, right) {
+            var selector = 'table.results-comparison a.'+left+', table.results-comparison a.'+right;
+            console.log(selector);
+            $('.has-component').removeClass('visible');
+            $(selector).addClass('visible');
+        }
+        function hide_invisible() {
+            $('tr.suite-body').each(function(){
+                var coll = $(this).find('a.test-result.visible');
+                var s = $(this).attr('data-suite');
+                if (!coll.length) {
+                    $('tr[data-suite="'+s+'"]').hide();
                 } else {
-                    $(this).show();
+                    $('tr[data-suite="'+s+'"]').show();
                 }
+                $(this).find('a').hide();
+                $(this).find('a.test-result.visible').show();
             });
         }
-
-        var update_unique = function() {
-            var elem = $('#toggleUniques');
-            if (elem.attr('data-value') == 'unique') {
-                elem.html('Unique Results');
-                $('.test-result').hide();
-                $('.test-result').removeClass('shown');
-                $('.test-result.unique').show();
-                $('.test-result.unique').addClass('shown');
-                $('.counter-results-unique').show();
-                $('.counter-results-all').hide();
-            } else {
-                elem.html('All Results'); 
-                $('.test-result').show();
-                $('.test-result').addClass('shown');
-                $('.counter-results-unique').hide();
-                $('.counter-results-all').show();
-            }
-            update_testsuites();
-            update_location_hash();
-        };
-
-
-        $('#toggleUniques').click(function(){
-            var elem = $(this);
-            if (elem.attr('data-value') == 'all') {
-                elem.attr('data-value', 'unique');
-            } else {
-                elem.attr('data-value', 'all');
-            }
-            update_unique();
-        });
-
-        var update_location_hash = function() {
-            var hashpieces = {
-                'components': '',
-                'show': ''
-            };
-            var components = [];
-            for (var i in selectedClasses) {
-                components.push('.'+i);
-            }
-            if (components.length > 0) {
-                hashpieces['components'] = components.join(',');
-            }
-            hashpieces['show'] = $('#toggleUniques').attr('data-value');
-    
-            var s = "";
-            for (var i in hashpieces) {
-                if (!hashpieces[i]) {
-                    continue;
-                }
-                var elem = i + "=" + hashpieces[i];
-                s += elem + ';';
-            }
-    
-            console.log(s);
-            window.location = '#'+s;
-        };
-
-        var refresh_components = function() {
-            $('.panel-comparison-testsuite').hide();
-            for (var i in selectedClasses) {
-                var selector = '.' + i;
-                $(selector).show();
-                $(selector).addClass('shown');
-            }
-            update_testsuites();
-            update_location_hash();
-        };
-
-        var select_cmp_selector = function(elem) {
-            var already_selected = elem.hasClass('list-group-item-success');
-            if (already_selected) {
-                elem.removeClass('list-group-item-success');
-                delete selectedClasses[elem.attr('data-cls')];
-            } else {
-                elem.addClass('list-group-item-success');
-                selectedClasses[elem.attr('data-cls')] = true;
-            }
-            refresh_components();
-        };
-
-        $(document).ready(function(){
-            var hsh = window.location.hash.replace(/^#/, '');
+        function process_history() {
+            var hsh = window.location.hash;
             if (!hsh) {
-                refresh_components();
-                update_unique();
                 return;
             }
-            var elems = hsh.split(';');
-            for (var i in elems) {
-                var piece = elems[i];
-                var tuple = piece.split('=');
-                if (tuple[0] == 'components') {
-                    var s = tuple[1];
-                    $(s).show();
-                    var selectors = s.split(',');
-                    for (var i in selectors) {
-                        var curated = selectors[i].replace(/^\./, '');
-                        selectedClasses[curated] = true;
-                        $("a[data-cls='"+curated+"']").addClass('list-group-item-success');
-                    }
-                } else if (tuple[0] == 'show') {
-                    $('#toggleUniques').attr('data-value', tuple[1]);
-                }
+            hsh = hsh.replace(/^#/, '');
+            var components = hsh.split(';');
+            for (var i in components) {
+                var current_component = components[i];
+                var elements = current_component.split('=');
+                window_parameters[elements[0]] = elements[1] || true;
             }
-            refresh_components();
-            update_unique();
-        });
-
-        $('a.component-selector-item').click(function(){
-            select_cmp_selector($(this));
-        });
+        }
+        function refresh_history() {
+            var buffer = [];
+            for (var i in window_parameters) {
+                buffer.push(i+'='+window_parameters[i]);
+            }
+            window.location.hash = '#'+buffer.join(';');
+        }
+        function window_make_visible() {
+            if(window_parameters['left'] && window_parameters['right']) {
+                $('.component-selector.'+window_parameters['left']).trigger('click');
+                $('.component-selector.'+window_parameters['right']).trigger('click');
+            }
+        }
+        process_history();
+        window_make_visible();
+        hide_invisible();
+    });
     </script>
 {% endblock %}
 

--- a/templates/sidebyside.html
+++ b/templates/sidebyside.html
@@ -75,7 +75,7 @@
             </tr>
         </thead>
         <tbody>
-            {% for suite, left, right in comparison %}{% if left|length + right|length > 0 %}
+            {% for suite, left, right in comparison.iter_all() %}{% if left|length + right|length > 0 %}
             <tr class="suite-header" data-suite="{{ suite }}">
                 <th colspan="2">{{ suite }}</th>
             </tr>

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+from .. import model
+from unittest import TestCase
+
+class TestTraggrModel(TestCase):
+
+    def test_initialization(self):
+        m = model.TestResult(
+            suite='dinosaurs',
+            test_id='t-rex',
+            result='failed',
+            component='jurassic',
+            sprint='01'
+        )
+        self.assertEqual(m.sprint, '01')
+        self.assertEqual(m.component, 'jurassic')
+        self.assertEqual(m.suite, 'dinosaurs')
+        self.assertEqual(m.test_id, 't-rex')
+        self.assertEqual(m.result, 'failed')
+        m = model.TestResult(nonexistent=123)
+        with self.assertRaises(AttributeError):
+            foo = m.nonexistent
+
+    def test_equality(self):
+        """
+        Test that model objects compare right.
+
+        The model objects are equal if and only if their suite, test_id, and result are equal.
+        """
+        m1 = model.TestResult(
+            sprint='s01',
+            component='component 1',
+            suite='TestSuite',
+            test_id='test_01',
+            result='passed'
+        )
+        m2 = model.TestResult(
+            sprint='s02',
+            component='utterly other component',
+            suite='TestSuite',
+            test_id='test_01',
+            result='passed'
+        )
+        self.assertEqual(m1, m2, 'The results are equal when their suite, result, and id are the same')
+        m2 = model.TestResult(
+            sprint='s02',
+            component='utterly other component',
+            suite='TestSuite',
+            test_id='test_01',
+            result='failed'
+        )
+        self.assertNotEqual(m1, m2, 'The results are different when results are not the same')
+        m2 = model.TestResult(
+            sprint='s02',
+            component='utterly other component',
+            suite='TestSuite',
+            test_id='test_02',
+            result='passed'
+        )
+        self.assertNotEqual(m1, m2, 'The results are different when test_ids are not the same')
+        m2 = model.TestResult(
+            sprint='s02',
+            component='utterly other component',
+            suite='AnotherTestSuite',
+            test_id='test_01',
+            result='passed'
+        )
+        self.assertNotEqual(m1, m2, 'The results are different when suites are not the same')
+
+    def test_sets(self):
+        """
+        Test results behavior when used in sets.
+        """
+        testset = set([
+            model.TestResult(
+                sprint='s01',
+                component='component 1',
+                suite='TestSuite',
+                test_id='test_01',
+                result='passed'
+            ),
+            model.TestResult(
+                sprint='s02',
+                component='utterly other component',
+                suite='TestSuite',
+                test_id='test_01',
+                result='failed'
+            ),
+            model.TestResult(
+                sprint='s03',
+                component='utterly other component',
+                suite='TestSuite',
+                test_id='test_01',
+                result='failed'
+            )
+        ])
+        self.assertEqual(len(testset), 2)
+        self.assertTrue(model.TestResult(
+            sprint='A completely different sprint',
+            component=None,
+            suite='TestSuite',
+            test_id='test_01',
+            result='failed'
+        ) in testset, 'set contains operation')
+        self.assertFalse(model.TestResult(
+            sprint='s01',
+            component='component 1',
+            suite='TestSuite',
+            test_id='test_02',
+            result='failed'
+        ) in testset, 'set contains operation')
+
+
+
+    def test_dictinterface(self):
+        m1 = model.TestResult(
+            sprint='s01',
+            component='component 1',
+            suite='TestSuite',
+            test_id='test_01',
+            result='passed'
+        )
+        self.assertEqual(m1['sprint'], 's01')
+        m1['sprint'] = 'Something else'
+        self.assertEqual(m1['sprint'], 'Something else')
+        with self.assertRaises(AttributeError):
+            m1['nonexistent'] = 'foo'
+        with self.assertRaises(IndexError):
+            a = m1['othernonexistent']
+
+    def test_comparison(self):
+        m1 = model.TestResultsComparison([
+            model.TestResult(sprint='s01', component='s01c01', suite='FirstSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s01', component='s01c01', suite='FirstSuite', test_id='test_02', result='error'),
+            model.TestResult(sprint='s01', component='s01c01', suite='SecondSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s02', component='s01c01', suite='FourthSuite', test_id='test_01', result='passed'),
+        ], [
+            model.TestResult(sprint='s02', component='s02c01', suite='FirstSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s02', component='s02c01', suite='FirstSuite', test_id='test_02', result='error'),
+            model.TestResult(sprint='s02', component='s02c01', suite='SecondSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s02', component='s02c01', suite='SecondSuite', test_id='test_02', result='passed'),
+            model.TestResult(sprint='s02', component='s02c01', suite='ThirdSuite', test_id='test_01', result='passed'),
+        ])
+        self.assertEqual(len(m1.suites), 4)
+        self.assertEqual(len(m1.left), 4)
+        self.assertEqual(len(m1.right), 5)
+        self.assertEqual(len(m1.left_by_suite['FirstSuite']), 0)
+        self.assertEqual(len(m1.all_left_by_suite['FirstSuite']), 2)
+        self.assertEqual(len(m1.right_by_suite['FirstSuite']), 0)
+        self.assertEqual(len(m1.all_right_by_suite['FirstSuite']), 2)
+        self.assertEqual(len(m1.left_by_suite['SecondSuite']), 0)
+        self.assertEqual(len(m1.all_left_by_suite['SecondSuite']), 1)
+        self.assertEqual(len(m1.right_by_suite['SecondSuite']), 1)
+        self.assertEqual(len(m1.all_right_by_suite['SecondSuite']), 2)
+        self.assertEqual(len(m1.left_by_suite['ThirdSuite']), 0)
+        self.assertEqual(len(m1.all_left_by_suite['ThirdSuite']), 0)
+        self.assertEqual(len(m1.right_by_suite['ThirdSuite']), 1)
+        self.assertEqual(len(m1.all_right_by_suite['ThirdSuite']), 1)
+        self.assertEqual(len(m1.left_by_suite['FourthSuite']), 1)
+        self.assertEqual(len(m1.all_left_by_suite['FourthSuite']), 1)
+        self.assertEqual(len(m1.right_by_suite['FourthSuite']), 0)
+        self.assertEqual(len(m1.all_right_by_suite['FourthSuite']), 0)
+        self.assertEqual(len(m1.components.keys()), 2)
+        suites = m1.suite_components('FirstSuite')
+        self.assertEqual(set(suites[0]), set(['s01c01']))
+        self.assertEqual(set(suites[1]), set(['s02c01']))
+
+    def test_comparison_iteration(self):
+        m1 = model.TestResultsComparison([
+            model.TestResult(sprint='s01', component='s01c01', suite='FirstSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s01', component='s01c01', suite='FirstSuite', test_id='test_02', result='error'),
+            model.TestResult(sprint='s01', component='s01c01', suite='SecondSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s02', component='s01c01', suite='FourthSuite', test_id='test_01', result='passed'),
+        ], [
+            model.TestResult(sprint='s02', component='s02c01', suite='FirstSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s02', component='s02c01', suite='FirstSuite', test_id='test_02', result='error'),
+            model.TestResult(sprint='s02', component='s02c01', suite='SecondSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s02', component='s02c01', suite='SecondSuite', test_id='test_02', result='passed'),
+            model.TestResult(sprint='s02', component='s02c01', suite='ThirdSuite', test_id='test_01', result='passed'),
+        ])
+        suite, left, right = next(m1)
+        self.assertEqual(suite, 'FirstSuite')
+        self.assertEqual(len(left), 0)
+        self.assertEqual(len(right), 0)
+        suite, left, right = next(m1)
+        self.assertEqual(suite, 'FourthSuite')
+        self.assertEqual(len(left), 1)
+        self.assertEqual(len(right), 0)
+        suite, left, right = next(m1)
+        self.assertEqual(suite, 'SecondSuite')
+        self.assertEqual(len(left), 0)
+        self.assertEqual(len(right), 1)
+        suite, left, right = next(m1)
+        self.assertEqual(suite, 'ThirdSuite')
+        self.assertEqual(len(left), 0)
+        self.assertEqual(len(right), 1)
+

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -195,3 +195,39 @@ class TestTraggrModel(TestCase):
         self.assertEqual(len(left), 0)
         self.assertEqual(len(right), 1)
 
+    def test_comparison_all_iteration(self):
+        m1 = model.TestResultsComparison([
+            model.TestResult(sprint='s01', component='s01c01', suite='FirstSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s01', component='s01c01', suite='FirstSuite', test_id='test_02', result='error'),
+            model.TestResult(sprint='s01', component='s01c01', suite='SecondSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s02', component='s01c01', suite='FourthSuite', test_id='test_01', result='passed'),
+        ], [
+            model.TestResult(sprint='s02', component='s02c01', suite='FirstSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s02', component='s02c01', suite='FirstSuite', test_id='test_02', result='error'),
+            model.TestResult(sprint='s02', component='s02c01', suite='SecondSuite', test_id='test_01', result='failed'),
+            model.TestResult(sprint='s02', component='s02c01', suite='SecondSuite', test_id='test_02', result='passed'),
+            model.TestResult(sprint='s02', component='s02c01', suite='ThirdSuite', test_id='test_01', result='passed'),
+        ])
+        iterator = m1.iter_all()
+        suite, left, right = next(iterator)
+        self.assertEqual(suite, 'FirstSuite')
+        self.assertEqual(len(left), 2)
+        self.assertEqual(len(right), 2)
+        self.assertEqual(len([x for x in left if x.unique]), 0)
+        self.assertEqual(len([x for x in right if x.unique]), 0)
+        suite, left, right = next(iterator)
+        self.assertEqual(suite, 'FourthSuite')
+        self.assertEqual(len(left), 1)
+        self.assertEqual(len(right), 0)
+        self.assertEqual(len([x for x in left if x.unique]), 1)
+        suite, left, right = next(iterator)
+        self.assertEqual(suite, 'SecondSuite')
+        self.assertEqual(len([x for x in left if x.unique]), 0)
+        self.assertEqual(len([x for x in right if x.unique]), 1)
+        self.assertEqual(len(left), 1)
+        self.assertEqual(len(right), 2)
+        suite, left, right = next(iterator)
+        self.assertEqual(suite, 'ThirdSuite')
+        self.assertEqual(len(left), 0)
+        self.assertEqual(len(right), 1)
+        self.assertEqual(len([x for x in right if x.unique]), 1)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -231,3 +231,24 @@ class TestTraggrModel(TestCase):
         self.assertEqual(len(left), 0)
         self.assertEqual(len(right), 1)
         self.assertEqual(len([x for x in right if x.unique]), 1)
+
+    def test_uniqueness(self):
+        m1 = model.TestResultsComparison([
+            model.TestResult(sprint='qa18-EDGEPRISM_4_2_7_0_011-Jul-05-1107', component='Component Load Tests', suite='TestSuiteStress404BackupHost', test_id='test_case_stress_rewrite_404_backup_tcphost_general_with_back_references_combined', result='failed'),
+        ], [
+            model.TestResult(sprint='qa18-EDGEPRISM_4_2_7_0_011-Jul-05-0407', component='Component Load Tests', suite='TestSuiteStress404BackupHost', test_id='test_case_stress_rewrite_404_backup_tcphost_general_with_back_references_combined', result='failed'),
+        ])
+        self.assertEqual(len(m1.all_left_by_suite['TestSuiteStress404BackupHost']), 1)
+        self.assertEqual(len(m1.all_right_by_suite['TestSuiteStress404BackupHost']), 1)
+        [self.assertFalse(x.unique) for x in m1.all_left_by_suite['TestSuiteStress404BackupHost']]
+        [self.assertFalse(x.unique) for x in m1.all_right_by_suite['TestSuiteStress404BackupHost']]
+
+    def test_components(self):
+        m1 = model.TestResultsComparison([
+            model.TestResult(sprint='qa18-EDGEPRISM_4_2_7_0_011-Jul-05-1107', component='Component Load Tests', suite='TestSuiteStress404BackupHost', test_id='test_case_stress_rewrite_404_backup_tcphost_general_with_back_references_combined', result='failed'),
+        ], [
+            model.TestResult(sprint='qa18-EDGEPRISM_4_2_7_0_011-Jul-05-0407', component='Component Load Tests', suite='TestSuiteStress404BackupHost', test_id='test_case_stress_rewrite_404_backup_tcphost_general_with_back_references_combined', result='failed'),
+        ])
+        self.assertEqual(len(m1.used_components(0)), 1)
+        self.assertEqual(len(m1.used_components(1)), 1)
+


### PR DESCRIPTION
- results are now not lost thanks to more robust comparison
- components are now correctly per-result and not per-suite
- brought back the per-suite view
- now only two sprints can be compared, and only one component from each may be selected
- simpler, more robust javascript
- comparisons are still bookmarkable
