### PR TITLE
AUTO-827 per-component failures are clickable now

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -48,10 +48,10 @@
 {% endfilter %}
 {% endmacro %}
 
-{% macro render_grouped_test_results(results, collapse, id) %}
+{% macro render_grouped_test_results(results, collapse, id, components_visible=True) %}
     <ul class="list-group collapse {% if not collapse %}in{% endif %}" id="{{ id }}">
     {% for component in results|sort %}
-        <li class="list-group-item">
+        <li class="list-group-item results-component" {% if not components_visible %}style="display: none"{% endif %} data-component="{{ component }}">
         <h4 class="list-group-item-heading">{{ component }}</h4>
         {% for suite in results[component]|sort %}
             <div class="panel panel-default">

--- a/templates/results.html
+++ b/templates/results.html
@@ -52,13 +52,22 @@
             countComparisonRows();
         });
 
-        $("#spanContextFailed").click(function() {
+        var all_components_visible = false;
 
-            if ($("#failedTestsList").is(":visible")) {
-                $("#failedTestsList").hide();
-            } else {
-                $("#failedTestsList").show();
-            };
+        $("#spanContextFailed").click(function() {
+            $('.results-component').each(function(){
+                if (all_components_visible) {
+                    $(this).hide();
+                    all_components_visible = false;
+                } else {
+                    $(this).show();
+                    all_components_visible = true;
+                }
+            });
+        });
+
+        $(".failed-component").click(function() {
+            $('.results-component[data-component="'+$(this).attr('data-component')+'"]').toggle();
         });
 
         window.removeComponentWithConfirmation = function(project, sprint, component) {
@@ -136,7 +145,7 @@
 
         <div class="alert alert-info" on>
             <a href="#" class="close" data-dismiss="alert" id="testinfo">&times;</a>
-            <strong>Note:</strong> Click a total failed tests badge to see a list of failed tests for all components.
+            <strong>Note:</strong> Click a failed tests badge to see a list of failed tests for that component, or total failed tests badge to see all failures.
         </div>
 
         <ul class="list-group">
@@ -156,7 +165,7 @@
                     <span class="badge alert-success pull-right">{{ component.passed }}</span>
                 {% endif %}
                 {% if component.failed != 0 %}
-                    <span class="badge alert-danger pull-right">{{ component.failed }}</span>
+                    <span class="badge alert-danger pull-right failed-component" data-component="{{ component.name }}">{{ component.failed }}</span>
                 {% endif %}
 
             </li>
@@ -197,8 +206,8 @@
 
         <br>
 
-        <div style="display:none" id="failedTestsList">
-            {{ render_grouped_test_results(failed_tests, False, "") }}
+        <div id="failedTestsList">
+            {{ render_grouped_test_results(failed_tests, False, "", False) }}
         </div>
 
         {% endif %}


### PR DESCRIPTION
Now any badge can be clicked to view failures for that component. Totals badge's behaviour was not altered.
